### PR TITLE
Increment Reference Counter For FindProcessByName Process

### DIFF
--- a/src/Driver/utils.c
+++ b/src/Driver/utils.c
@@ -19,6 +19,7 @@ NTSTATUS FindProcessByName(CHAR* process_name, PEPROCESS* process)
 			RtlCopyMemory((PVOID)&active_threads, (PVOID)((uintptr_t)cur_entry + 0x5f0) /*EPROCESS->ActiveThreads*/, sizeof(active_threads));
 			if (active_threads)
 			{
+				ObReferenceObject(cur_entry);
 				*process = cur_entry;
 				return STATUS_SUCCESS;
 			}


### PR DESCRIPTION
Getting a reference to the process from the active process list doesn't increment the reference counter, if the process is marked for deletion and no references are held, the process will be freed and any code that accesses this process will be accessing freed memory.