### PR TITLE
Memory leak

### DIFF
--- a/src/Driver/spoof.c
+++ b/src/Driver/spoof.c
@@ -46,6 +46,7 @@ PETHREAD GetWin32Thread(PVOID* win32Thread)
 
 		if (PsIsThreadTerminating(currentEthread))
 		{
+			ObDereferenceObject(currentEthread);
 			currentThreadId++;
 			continue;
 		}
@@ -64,6 +65,8 @@ PETHREAD GetWin32Thread(PVOID* win32Thread)
 				return currentEthread;
 			}
 		}
+
+		ObDereferenceObject(currentEthread);
 		currentThreadId++;
 	} while (0x3000 > currentThreadId);
 


### PR DESCRIPTION
Reference counter is not lowered after being increased by PsLookupThreadByThreadId, thousands of threads will not be able to be deleted, and waste memory.